### PR TITLE
feat: automatic "get" route generation

### DIFF
--- a/brickworks/core/acl/policies.py
+++ b/brickworks/core/acl/policies.py
@@ -2,10 +2,9 @@ from sqlalchemy import and_, select
 
 from brickworks.core import execution_context
 from brickworks.core.acl.base_policy import BasePolicy, PolicyTypeEnum
-from brickworks.core.models import BaseDBModel, UserModel
+from brickworks.core.models import BaseDBModel
 from brickworks.core.models.base_view import BaseView
 from brickworks.core.models.role_model import role_acl_table
-from brickworks.core.models.user_model import UserStatusEnum
 from brickworks.core.utils.sqlalchemy import AlwaysFalseWhereClause, AlwaysTrueWhereClause, TypeWhereClause
 
 
@@ -31,6 +30,8 @@ class AllowActiveUserAccessPolicy(BasePolicy):
     policy_type = PolicyTypeEnum.PERMISSIVE
 
     async def filter(self, obj_class: type["BaseDBModel"] | type["BaseView"]) -> TypeWhereClause:
+        from brickworks.core.models.user_model import UserModel, UserStatusEnum
+
         if execution_context.user_uuid is None:
             return AlwaysFalseWhereClause
         user = await UserModel.get_one_or_none(uuid=execution_context.user_uuid)
@@ -54,6 +55,8 @@ class RoleAllowPolicy(BasePolicy):
         self.permission = permission
 
     async def filter(self, obj_class: type["BaseDBModel"]) -> TypeWhereClause:
+        from brickworks.core.models.user_model import UserModel
+
         if execution_context.user_uuid is None:
             # if no user is provided, we assume public access (which has no roles)
             return AlwaysFalseWhereClause
@@ -92,6 +95,8 @@ class RoleBasedAccessPolicy(BasePolicy):
             self.policy_type = PolicyTypeEnum.RESTRICTIVE
 
     async def filter(self, obj_class: type["BaseDBModel"] | type["BaseView"]) -> TypeWhereClause:
+        from brickworks.core.models.user_model import UserModel
+
         if execution_context.user_uuid is None:
             # if no user is provided, we assume public access (which has no roles)
             return AlwaysFalseWhereClause

--- a/brickworks/core/exceptions.py
+++ b/brickworks/core/exceptions.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 class CustomException(HTTPException):
     headers: dict[str, str] | None = None
     msg: str
-    type: str
+    type: str = "custom_error"
     loc: list[str] | None = []
 
     def __init__(self, msg: str | None = None) -> None:
@@ -22,18 +22,21 @@ class CustomException(HTTPException):
 
 
 class NotFoundException(CustomException):
+    type: str = "not_found"
     status_code: int = 404
 
 
 class UnauthorizedException(CustomException):
+    type: str = "unauthorized"
     status_code: int = 401
 
 
 class ForbiddenException(CustomException):
+    type: str = "forbidden"
     status_code: int = 403
 
 
 class DuplicateException(CustomException):
     status_code: int = 409
-    type: str = "duplicate_error"
+    type: str = "duplicate"
     msg: str = "Duplicate entry found"

--- a/brickworks/core/models/base_view.py
+++ b/brickworks/core/models/base_view.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from typing import Any, TypeVar
 
-from sqlalchemy import Select, and_
+from sqlalchemy import Select, and_, func, select
 
 from brickworks.core import db
 from brickworks.core.acl.base_policy import BasePolicy
@@ -110,8 +110,6 @@ class BaseView(BaseSchema):
         cls: type[BaseViewType],
         _filter_clause: TypeWhereClause | None = None,
         _order_by: TypeOrderBy | None = None,
-        _per_page: int = -1,
-        _page: int = 1,
         **kwargs: Any,  # noqa: ANN401
     ) -> Sequence[BaseViewType]:
         """
@@ -134,8 +132,32 @@ class BaseView(BaseSchema):
             _apply_policies=True,
             _filter_clause=_filter_clause,
             _order_by=_order_by,
+            **kwargs,
+        )
+
+    @classmethod
+    async def get_paginated_list_with_policies(
+        cls: type[BaseViewType],
+        _per_page: int,
+        _page: int,
+        _filter_clause: TypeWhereClause | None = None,
+        _order_by: TypeOrderBy | None = None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> tuple[Sequence[BaseViewType], int]:
+        """
+        Retrieve a paginated list of database rows and the total count.
+        This method applies all restrictive (AND) and permissive (OR) policies defined in
+        __policies__ of the __model_class__.
+
+        Requires _per_page and _page parameters.
+        Returns a tuple: (items, total_count)
+        """
+        return await cls.get_paginated_list(
             _per_page=_per_page,
             _page=_page,
+            _apply_policies=True,
+            _filter_clause=_filter_clause,
+            _order_by=_order_by,
             **kwargs,
         )
 
@@ -145,8 +167,6 @@ class BaseView(BaseSchema):
         _apply_policies: bool = False,
         _filter_clause: TypeWhereClause | None = None,
         _order_by: TypeOrderBy | None = None,
-        _per_page: int = -1,
-        _page: int = 1,
         **kwargs: Any,  # noqa: ANN401
     ) -> Sequence[BaseViewType]:
         """
@@ -164,13 +184,61 @@ class BaseView(BaseSchema):
 
         Returns a sequence of matching rows.
         """
+        return (
+            await cls._get_list_common(
+                _apply_policies=_apply_policies,
+                _filter_clause=_filter_clause,
+                _order_by=_order_by,
+                _per_page=-1,
+                _page=1,
+                **kwargs,
+            )
+        )[0]
+
+    @classmethod
+    async def get_paginated_list(
+        cls: type[BaseViewType],
+        _per_page: int,
+        _page: int,
+        _apply_policies: bool = False,
+        _filter_clause: TypeWhereClause | None = None,
+        _order_by: TypeOrderBy | None = None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> tuple[Sequence[BaseViewType], int]:
+        """
+        Retrieve a paginated list of database rows and the total count.
+        Requires _per_page and _page parameters.
+        Returns a tuple: (items, total_count)
+        """
+        return await cls._get_list_common(
+            _apply_policies=_apply_policies,
+            _filter_clause=_filter_clause,
+            _order_by=_order_by,
+            _per_page=_per_page,
+            _page=_page,
+            **kwargs,
+        )
+
+    @classmethod
+    async def _get_list_common(
+        cls: type[BaseViewType],
+        _apply_policies: bool = False,
+        _filter_clause: TypeWhereClause | None = None,
+        _order_by: TypeOrderBy | None = None,
+        _per_page: int = -1,
+        _page: int = 1,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> tuple[Sequence[BaseViewType], int]:
+        """
+        Retrieve a paginated list of database rows and the total count.
+        Returns a tuple: (items, total_count)
+        """
         query = cls.__select__
         if _apply_policies:
             if not cls.__policy_model_class__:
                 raise ValueError("Cannot apply policies without a model class")
             query = await cls.__policy_model_class__.apply_policies_to_query(query, policies=cls.__policies__ or None)
 
-        # Map kwargs to columns in __select__ using their labels
         label_to_column = {col._label: col for col in query.selected_columns}
         if kwargs:
             filters = []
@@ -184,6 +252,14 @@ class BaseView(BaseSchema):
         if _filter_clause is not None:
             query = query.where(_filter_clause)
 
+        if _per_page > 0:
+            # Count query
+            count_query = select(func.count()).select_from(query.subquery())
+            total = (await db.session.execute(count_query)).scalar_one()
+        else:
+            total = -1
+
+        # Pagination and ordering
         if _order_by is not None:
             query = query.order_by(*_order_by if isinstance(_order_by, list) else [_order_by])
         if _per_page > 0:
@@ -191,4 +267,5 @@ class BaseView(BaseSchema):
 
         result = await db.session.execute(query)
         rows = result.unique()
-        return [cls(**dict(zip(row._fields, row._t, strict=True))) for row in rows]
+        items = [cls(**dict(zip(row._fields, row._t, strict=True))) for row in rows]
+        return items, total

--- a/brickworks/core/models/mixins.py
+++ b/brickworks/core/models/mixins.py
@@ -1,0 +1,62 @@
+from collections.abc import Sequence
+from typing import Any
+
+from fastapi import APIRouter
+
+from brickworks.core.exceptions import NotFoundException
+from brickworks.core.models.base_dbmodel import BaseDBModel
+from brickworks.core.models.base_view import BaseView
+
+
+class WithGetRouteMixin:
+    """
+    Mixin to add a get route to any class with a get_list_with_policies classmethod.
+    """
+
+    __routing_path__: str  # The path for the GET route, must be defined in the subclass.
+    __routing_get_key__: str | None = None  # Optional key to use for the GET route, defaults to None.
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # noqa: ANN401
+        super().__init_subclass__(**kwargs)
+        if not issubclass(cls, BaseView) and not issubclass(cls, BaseDBModel):
+            raise TypeError(f"{cls.__name__} must be a subclass of BaseView or BaseDBModel to use WithGetRouteMixin.")
+        if not hasattr(cls, "__routing_path__"):
+            raise ValueError(f"{cls.__name__} must define a __routing_path__ attribute to use WithGetRouteMixin.")
+        if not cls.__routing_path__:
+            raise ValueError(f"{cls.__name__} must define a __routing_path__ attribute to use WithGetRouteMixin.")
+
+    @classmethod
+    def get_router(cls) -> APIRouter:
+        if not issubclass(cls, BaseView) and not issubclass(cls, BaseDBModel):
+            raise TypeError(f"{cls.__name__} must be a subclass of BaseView or BaseDBModel to use WithGetRouteMixin.")
+
+        router = APIRouter()
+
+        async def _get_all() -> Sequence[BaseView | BaseDBModel]:
+            return await cls.get_list_with_policies()
+
+        router.add_api_route(
+            cls.__routing_path__,
+            _get_all,
+            response_model=list[cls],  # type: ignore
+            summary=f"Get all {cls.__name__} objects",
+            description=f"Get all {cls.__name__} objects with optional filtering, ordering, and pagination.",
+        )
+        routing_get_key = cls.__routing_get_key__
+        if routing_get_key:
+
+            async def _get_by_key(key: str) -> BaseView | BaseDBModel | None:
+                result = await cls.get_one_or_none_with_policies(_filter_clause=None, **{routing_get_key: key})
+                if not result:
+                    raise NotFoundException(f"{cls.__name__} with {routing_get_key} '{key}' not found.")
+                return result
+
+            router.add_api_route(
+                f"{cls.__routing_path__}/{{key}}",
+                _get_by_key,
+                response_model=cls | None,
+                summary=f"Get a {cls.__name__} object by {cls.__routing_get_key__}",
+                description=f"Get a {cls.__name__} object by {cls.__routing_get_key__}.",
+            )
+
+        return router

--- a/brickworks/core/module_loader.py
+++ b/brickworks/core/module_loader.py
@@ -11,6 +11,7 @@ from typing import TypeVar
 from pydantic import BaseModel
 
 from brickworks.core.models.base_dbmodel import BaseDBModel
+from brickworks.core.models.base_view import BaseView
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,14 @@ def get_models_by_fqpn() -> dict[str, type[BaseDBModel]]:
     models_filtered = [model for model in models if hasattr(model, "__tablename__")]
 
     return {model.fqpn(): model for model in models_filtered}
+
+
+@lru_cache
+def get_views() -> list[type[BaseView]]:
+    views = get_all_subclasses(BaseView)
+    # remove abstract views
+    views_filtered = [view for view in views if hasattr(view, "__select__")]
+    return views_filtered
 
 
 def _get_module_json_path(module_name: str) -> str:

--- a/brickworks/core/schemas/base_schema.py
+++ b/brickworks/core/schemas/base_schema.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
 from datetime import datetime
+from typing import Generic, TypeVar
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from brickworks.core.utils.timeutils import convert_datetime_to_iso_8601_with_z_suffix
 
@@ -15,3 +17,13 @@ class BaseSchema(BaseModel):
     model_config = ConfigDict(
         json_encoders={datetime: convert_datetime_to_iso_8601_with_z_suffix}, from_attributes=True
     )
+
+
+T = TypeVar("T")
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: Sequence[T] = Field(..., description="List of items on this page.")
+    total: int = Field(..., description="Total number of items available.")
+    page: int = Field(..., description="Current page number (1-based).")
+    page_size: int = Field(..., description="Number of items per page.")

--- a/brickworks/core/server.py
+++ b/brickworks/core/server.py
@@ -8,7 +8,8 @@ from brickworks.core.auth.csrf import CSRFMiddleware
 from brickworks.core.auth.executioncontext import ExecutionContextMiddleware
 from brickworks.core.auth.session import SessionMiddleware
 from brickworks.core.db import DBSessionMiddleware
-from brickworks.core.module_loader import load_modules
+from brickworks.core.models.mixins import WithGetRouteMixin
+from brickworks.core.module_loader import get_views, load_modules
 from brickworks.core.utils.importer import import_object_from_path
 
 logging.basicConfig(level=logging.INFO)
@@ -23,6 +24,7 @@ def create_app(for_testing: bool = False) -> FastAPI:
     # (to ensure it has access to sessions and the database)
     for brick in load_modules():
         _add_routers(app_api, brick.routers)
+        _add_view_routes(app_api)
         _add_middlewares(app_api, brick.middlewares)
 
     if not for_testing:
@@ -55,6 +57,14 @@ def create_app(for_testing: bool = False) -> FastAPI:
 def _add_routers(app: FastAPI, routers: list[str]) -> None:
     for router_path in routers:
         router = import_object_from_path(router_path)
+        app.include_router(router)
+
+
+def _add_view_routes(app: FastAPI) -> None:
+    views = get_views()
+    views_with_routes = [view for view in views if issubclass(view, WithGetRouteMixin)]
+    for view in views_with_routes:
+        router = view.get_router()
         app.include_router(router)
 
 

--- a/docs/concepts/database_models.md
+++ b/docs/concepts/database_models.md
@@ -63,6 +63,32 @@ By default these methods will apply access policies.
 
 You can also pass additional filters, ordering, and pagination options to these methods.
 
+## Pagination
+
+Database models support efficient pagination out of the box. You can use the `get_paginated_list` method to retrieve a specific page of results along with the total number of matching records.
+
+### Usage Example
+
+```python
+items, total = await BookModel.get_paginated_list(_per_page=10, _page=2)
+print(f"Total books: {total}")
+for book in items:
+    print(book.title)
+```
+
+- `_per_page`: Number of items per page (required)
+- `_page`: Page number (1-based, required)
+- Returns a tuple: `(items, total)` where `items` is a list of model/view instances and `total` is the total number of matching records (ignoring pagination)
+
+You can also filter and order results as with `get_list`:
+
+```python
+items, total = await BookModel.get_paginated_list(_per_page=5, _page=1, author="J.R.R. Tolkien")
+```
+
+!!! note
+    Pagination is efficient: the total count is computed in the database using the same filters and policies as the data query.
+
 ## Relationships
 
 Models can define relationships to other models, such as one-to-many or many-to-many associations. Use SQLAlchemy's `relationship` and `ForeignKey` to set these up.

--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -1,0 +1,79 @@
+# Routing
+
+Brickworks is based on FastAPI, so you can define routes just as you would in any FastAPI project. Bricks can register their own routers, and you can organize your API by splitting routes into different modules and bricks.
+
+## Registering Routes
+
+To add routes, define them in your brick's routers module and register them in the `brick.json` file:
+
+```python title="app/mybrick/routers/__init__.py"
+from fastapi import APIRouter
+
+r = APIRouter(prefix="/myroutes")
+
+@r.get("/")
+async def hello_world():
+    return "Hello World"
+```
+
+```json title="app/mybrick/brick.json"
+{
+  "routers": ["app.mybrick.routers.r"],
+  "middlewares": [],
+  "loadme": []
+}
+```
+
+## Automatic Routes for models and views
+
+Brickworks provides a powerful mixin, `WithGetRouteMixin`, that can be added to any model or view class to automatically generate RESTful GET endpoints for listing and retrieving objects.
+
+### How it works
+
+Add `WithGetRouteMixin` to your model or view class and define the `__routing_path__` and (optionally) `__routing_get_key__` attributes. The mixin will automatically create:
+- A paginated GET endpoint at `__routing_path__` (e.g. `/api/books`) returning a paginated response.
+- A GET endpoint at `__routing_path__/{key}` for fetching a single object by its key (e.g. `/api/books/{uuid}`).
+
+**All endpoints are automatically secured by the policies set for the model or view.** This means that any access control or filtering logic you define in your model's or view's `__policies__` will be enforced for all requests to these endpoints.
+
+This works exactly the same for both models and views. For more details on defining models and views, see the [database models](database_models.md) and [view models](view_models.md) documentation.
+
+### Example: Adding routes to a model or view
+
+```python
+from brickworks.core.models.base_dbmodel import BaseDBModel
+from brickworks.core.models.mixins import WithGetRouteMixin
+
+class BookModel(BaseDBModel, WithGetRouteMixin):
+    __routing_path__ = "/books"
+    __routing_get_key__ = "uuid"
+    # ... define fields ...
+```
+
+This will automatically provide:
+- `GET /api/books?page=1&page_size=100` (paginated list)
+- `GET /api/books/{uuid}` (single object by key)
+
+You can use the same pattern for views by inheriting from `BaseView` instead of `BaseDBModel`.
+
+### Response Schema
+
+Paginated list endpoints return a `PaginatedResponse` object:
+
+```json
+{
+  "items": [ ... ],
+  "total": 123,
+  "page": 1,
+  "page_size": 100
+}
+```
+
+### Customization
+
+- You can override the default page size and add additional query parameters by customizing the `_get_all` method in your class.
+- The mixin respects all policies and filters defined on your model or view.
+
+---
+
+For more details on how to use routers and the route mixin, see the [database models](database_models.md) and [view models](view_models.md) documentation.

--- a/docs/concepts/view_models.md
+++ b/docs/concepts/view_models.md
@@ -79,3 +79,29 @@ async def get_roles_per_user_list():
 
 !!! note
     View models are read-only and cannot be used to insert or update data. They are intended for querying and presenting data only.
+
+## Pagination
+
+View models support efficient pagination using the `get_paginated_list` method, which returns a specific page of results and the total number of matching records.
+
+### Usage Example
+
+```python
+items, total = await RolesPerUserView.get_paginated_list(_per_page=10, _page=1)
+print(f"Total users: {total}")
+for user in items:
+    print(user.user_name, user.role_count)
+```
+
+- `_per_page`: Number of items per page (required)
+- `_page`: Page number (1-based, required)
+- Returns a tuple: `(items, total)` where `items` is a list of view instances and `total` is the total number of matching records (ignoring pagination)
+
+You can also filter and order results as with `get_list`:
+
+```python
+items, total = await RolesPerUserView.get_paginated_list(_per_page=5, _page=1, family_name="Smith")
+```
+
+!!! note
+    Pagination is efficient: the total count is computed in the database using the same filters and policies as the data query.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -47,3 +47,4 @@ nav:
       - Database Models: concepts/database_models.md
       - Views Models: concepts/view_models.md
       - Access Control: concepts/access_control.md
+      - Routing: concepts/routing.md

--- a/tests/core/test_view.py
+++ b/tests/core/test_view.py
@@ -86,6 +86,16 @@ async def test_user_role_view(app: TestApp) -> None:
     assert alice_count is not None
     assert alice_count.role_count == 2
 
+    # test get one or none
+    alice_role = await UserRoleViewTest.get_one_or_none(role_name="admin", user_name="Alice Smith")
+    assert alice_role is not None
+    assert alice_role.role_name == "admin"
+
+    # test get list with filtering by key
+    user_roles_filtered = await UserRoleViewTest.get_list(role_name="user")
+    assert len(user_roles_filtered) >= 3
+    assert all(role.role_name == "user" for role in user_roles_filtered)
+
 
 async def test_user_role_view_with_policies(app: TestApp) -> None:
     """

--- a/tests/core/test_view.py
+++ b/tests/core/test_view.py
@@ -13,7 +13,7 @@ user_alias = aliased(UserModel)
 role_alias = aliased(RoleModel)
 
 
-class UserRoleViewTest(BaseView):
+class UserRoleTestView(BaseView):
     """
     View displaying user roles.
     """
@@ -33,22 +33,24 @@ class UserRoleViewTest(BaseView):
     __policies__ = [RoleBasedAccessPolicy("admin")]
 
 
-class RolesPerUserViewTest(BaseView):
+class RolesPerUserTestView(BaseView):
     """
     View displaying each user and counts the number of roles they have.
     """
 
     user_name: str
     role_count: int
+    family_name: str
 
     __select__ = (
         select(
             user_alias.name.label("user_name"),
             func.count(user_role_table.c.role_uuid).label("role_count"),
+            user_alias.family_name.label("family_name"),
         )
         .select_from(user_alias)
         .join(user_role_table, user_alias.uuid == user_role_table.c.user_uuid)
-        .group_by(user_alias.name)
+        .group_by(user_alias.name, user_alias.family_name)
     )
     __policy_model_class__ = UserModel
     __policies__ = [RoleBasedAccessPolicy("admin")]
@@ -74,25 +76,25 @@ async def test_user_role_view(app: TestApp) -> None:
     await charlie.add_role(role_user)
 
     # Query the user role view
-    user_roles = await UserRoleViewTest.get_list()
+    user_roles = await UserRoleTestView.get_list()
     assert len(user_roles) >= 4
     alice_roles = [role for role in user_roles if role.user_name == "Alice Smith"]
     assert len(alice_roles) == 2
 
     # Query the user count view
-    user_count = await RolesPerUserViewTest.get_list()
+    user_count = await RolesPerUserTestView.get_list()
     assert len(user_count) >= 3
     alice_count = next((user for user in user_count if user.user_name == "Alice Smith"), None)
     assert alice_count is not None
     assert alice_count.role_count == 2
 
     # test get one or none
-    alice_role = await UserRoleViewTest.get_one_or_none(role_name="admin", user_name="Alice Smith")
+    alice_role = await UserRoleTestView.get_one_or_none(role_name="admin", user_name="Alice Smith")
     assert alice_role is not None
     assert alice_role.role_name == "admin"
 
     # test get list with filtering by key
-    user_roles_filtered = await UserRoleViewTest.get_list(role_name="user")
+    user_roles_filtered = await UserRoleTestView.get_list(role_name="user")
     assert len(user_roles_filtered) >= 3
     assert all(role.role_name == "user" for role in user_roles_filtered)
 
@@ -115,19 +117,52 @@ async def test_user_role_view_with_policies(app: TestApp) -> None:
 
     async with ExecutionContext(alice.uuid):
         # Alice does not have the admin role, so she should not see any results
-        user_roles = await UserRoleViewTest.get_list_with_policies()
+        user_roles = await UserRoleTestView.get_list_with_policies()
         assert len(user_roles) == 0
-        user_count = await RolesPerUserViewTest.get_list_with_policies()
+        user_count = await RolesPerUserTestView.get_list_with_policies()
         assert len(user_count) == 0
 
         await alice.add_role(role_admin)
 
         # Now Alice has the admin role, so she should see all users
-        user_roles = await UserRoleViewTest.get_list_with_policies()
+        user_roles = await UserRoleTestView.get_list_with_policies()
         assert len(user_roles) >= 4
 
-        user_count = await RolesPerUserViewTest.get_list_with_policies()
+        user_count = await RolesPerUserTestView.get_list_with_policies()
         assert len(user_count) >= 3
         alice_count = next((user for user in user_count if user.user_name == "Alice Smith"), None)
         assert alice_count is not None
         assert alice_count.role_count == 2
+
+
+async def test_roles_per_user_view_pagination(app: TestApp) -> None:
+    # Use a unique family_name for test isolation
+    family_name = "PaginateViewTestFamily"
+    # Create 25 users, each with a role
+    role = await RoleModel(role_name="paginated_role").persist()
+    for i in range(25):
+        user = await create_test_user(f"PaginateViewTestUser{i}", family_name)
+        await user.add_role(role)
+
+    # Page 1, page size 10
+    items, total = await RolesPerUserTestView.get_paginated_list(_per_page=10, _page=1, family_name=family_name)
+    assert len(items) == 10
+    assert total == 25
+    assert all(item.family_name == family_name for item in items)
+
+    # Page 2, page size 10
+    items, total = await RolesPerUserTestView.get_paginated_list(_per_page=10, _page=2, family_name=family_name)
+    assert len(items) == 10
+    assert total == 25
+    assert all(item.family_name == family_name for item in items)
+
+    # Page 3, page size 10 (should have 5 users)
+    items, total = await RolesPerUserTestView.get_paginated_list(_per_page=10, _page=3, family_name=family_name)
+    assert len(items) == 5
+    assert total == 25
+    assert all(item.family_name == family_name for item in items)
+
+    # Page 4, page size 10 (should be empty)
+    items, total = await RolesPerUserTestView.get_paginated_list(_per_page=10, _page=4, family_name=family_name)
+    assert len(items) == 0
+    assert total == 25


### PR DESCRIPTION
Added `WithGetRouteMixin` that automatically generates list and get-by-key endpoints for models and views.