### PR TITLE
Feat: Improve cache

### DIFF
--- a/brickworks/core/cache.py
+++ b/brickworks/core/cache.py
@@ -107,7 +107,9 @@ class BrickworksCache:
             )
             self._add_to_set_script = self._redis_client.register_script(ADD_TO_SET_SCRIPT)
         else:
-            logger.warning("Using memory cache. This is not recommended for production use.")
+            logger.warning(
+                "Using memory cache. Do not use this for production, as this might leak memory and is not distributed!"
+            )
 
     def _generate_key(self, key: str, namespace: str, master_tenant: bool) -> str:
         tenant: str = settings.MASTER_DB_SCHEMA

--- a/brickworks/core/cache.py
+++ b/brickworks/core/cache.py
@@ -202,8 +202,8 @@ class BrickworksCache:
         If nx is True, only set if key does not exist (like Redis SETNX).
         Returns True if the key was set, False otherwise.
         """
-        if not isinstance(value, str | bytes):
-            raise ValueError(f"Cached value must be a string. Got {type(value)}")
+        if not isinstance(value, (str, bytes)):
+            raise ValueError(f"Cached value must be a string or bytes. Got {type(value)}")
 
         cache_key = self._generate_key(key, namespace=namespace, master_tenant=master_tenant)
         if settings.USE_REDIS:

--- a/brickworks/core/models/tenant_model.py
+++ b/brickworks/core/models/tenant_model.py
@@ -13,7 +13,7 @@ from brickworks.core.settings import settings
 logger = logging.getLogger(__name__)
 
 
-@cache.lru_cache(master_tenant=True, expire=60)
+@cache.func_cache(master_tenant=True, expire=60)
 async def get_domain_schema_mapping() -> dict[str, str]:
     return await _get_domain_schema_mapping()
 

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -1,6 +1,6 @@
 # Caching
 
-The `BrickworksCache` class provides a unified interface for caching in memory or Redis, supporting both key-value and queue-based operations, as well as distributed locking and an async LRU cache decorator.
+The `BrickworksCache` class provides a unified interface for caching in memory or Redis, supporting both key-value and queue-based operations, as well as distributed locking and an async function cache decorator.
 The cache is fully async, meaning you can NOT use it from within syncronous functions!
 
 !!! warning
@@ -99,12 +99,12 @@ Returns `True` if the lock was acquired.
 await cache.release_distributed_lock("lock_name")
 ```
 
-## LRU Cache Decorator
+## Function Cache Decorator
 
 You can cache the results of async functions with JSON-serializable arguments and pickleable return values:
 
 ```python
-@cache.lru_cache(expire=60)
+@cache.func_cache(expire=60)
 async def compute(a: int, b: int) -> int:
     ...
 ```
@@ -117,12 +117,12 @@ await compute.cache_clear()
 
 Note: the cache is only cleared for the currently active tenant!
 
-There are a few key differences between `functools.lru_cache` and Brickworks `cache.lru_cache`
+There are a few key differences between `functools.func_cache` and Brickworks `cache.func_cache`
 
 - **Tenant Awareness:** The Brickworks cache is tenant-aware, so results are isolated per tenant by default.
 - **Distributed Cache:** If enabled, the Brickworks cache is stored in Redis. This enables multiple replicas of the application to share the same cache.
 - **Time based expire:** Cached results expire automatically after a certain time. (default 1 week)
-- **Async only:** Brickworks lru_cache only works with async functions, because otherwise the async redis connection could not be used
+- **Async only:** Brickworks func_cache only works with async functions, because otherwise the async redis connection could not be used
 
 ## Indexing and Listing Keys
 
@@ -175,8 +175,8 @@ val = await cache.get_key("foo")
 await cache.push_to_queue("myqueue", "item1")
 item = await cache.pop_from_queue("myqueue")
 
-# Use the LRU cache decorator
-@cache.lru_cache(expire=120)
+# Use the func cache decorator
+@cache.func_cache(expire=120)
 async def add(a: int, b: int) -> int:
     return a + b
 result = await add(1, 2)

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -4,7 +4,7 @@ The `BrickworksCache` class provides a unified interface for caching in memory o
 The cache is fully async, meaning you can NOT use it from within syncronous functions!
 
 !!! warning
-    For production it is strongly advised to use Redis, because otherwise the cache is not shared between multiple replicas of your application!
+    The memory version is only ment for running tests without having Redis available. Do NOT use the memory version for production as it is not shared between multiple replicas of your application and might leak memory!
 
 The Redis connection can be configured with the following environment variables:
 

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -101,7 +101,7 @@ await cache.release_distributed_lock("lock_name")
 
 ## LRU Cache Decorator
 
-You can cache the results of async functions with JSON-serializable arguments and return values:
+You can cache the results of async functions with JSON-serializable arguments and pickleable return values:
 
 ```python
 @cache.lru_cache(expire=60)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ select = [
     "T20"
 ]
 
+ignore = [
+    "UP038" # deprecated
+]
+
 [tool.mypy]
 strict = true
 ignore_missing_imports = true

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -257,7 +257,11 @@ async def test_set_tenant_isolation(app: TestApp, cache_backend: TCacheBackendFi
 async def test_index_add_and_cleanup(app: TestApp, cache_backend: TCacheBackendFixture) -> None:
     # Add two keys with the same index
     await cache.set_key("k1", "v1", namespace="test", indices=["myindex"])
+    k1 = await cache.get_key("k1", namespace="test")
+    assert k1 == "v1"
     await cache.set_key("k2", "v2", namespace="test", indices=["myindex"])
+    k2 = await cache.get_key("k2", namespace="test")
+    assert k2 == "v2"
     # Both keys should be listed by index
     keys = await cache.list_keys_by_index("myindex", namespace="test")
     assert set(keys) == {"k1", "k2"}

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -119,7 +119,7 @@ async def test_acquire_and_release_lock(app: TestApp, cache_backend: TCacheBacke
 async def test_lru_cache_simple(app: TestApp, cache_backend: TCacheBackendFixture) -> None:
     call_counter = {"count": 0}
 
-    @cache.lru_cache(expire=2)
+    @cache.func_cache(expire=2)
     async def add(a: int, b: int) -> int:
         call_counter["count"] += 1
         return a + b
@@ -144,7 +144,7 @@ async def test_lru_cache_simple(app: TestApp, cache_backend: TCacheBackendFixtur
 async def test_lru_cache_with_kwargs(app: TestApp, cache_backend: TCacheBackendFixture) -> None:
     call_counter = {"count": 0}
 
-    @cache.lru_cache(expire=2)
+    @cache.func_cache(expire=2)
     async def concat(a: int, b: int = 0) -> str:
         call_counter["count"] += 1
         return f"{a}-{b}"
@@ -160,7 +160,7 @@ async def test_lru_cache_with_kwargs(app: TestApp, cache_backend: TCacheBackendF
 
 @pytest.mark.asyncio
 async def test_lru_cache_json_serialization_error(app: TestApp, cache_backend: TCacheBackendFixture) -> None:
-    @cache.lru_cache(expire=2)
+    @cache.func_cache(expire=2)
     async def unserializable(arg: int) -> object:
         class NotSerializable:
             pass
@@ -175,7 +175,7 @@ async def test_lru_cache_json_serialization_error(app: TestApp, cache_backend: T
 async def test_lru_cache_tenant_isolation(app: TestApp, cache_backend: TCacheBackendFixture) -> None:
     call_counter = {"count": 0}
 
-    @cache.lru_cache(expire=2)
+    @cache.func_cache(expire=2)
     async def add(a: int, b: int) -> int:
         call_counter["count"] += 1
         return a + b
@@ -336,7 +336,7 @@ async def test_index_tenant_isolation(app: TestApp, cache_backend: TCacheBackend
 async def test_lru_cache_clear(app: TestApp, cache_backend: TCacheBackendFixture) -> None:
     call_counter = {"count": 0}
 
-    @cache.lru_cache(expire=10)
+    @cache.func_cache(expire=10)
     async def add(a: int, b: int) -> int:
         call_counter["count"] += 1
         return a + b
@@ -364,7 +364,7 @@ async def test_lru_cache_clear(app: TestApp, cache_backend: TCacheBackendFixture
 async def test_lru_cache_clear_tenant_isolation(app: TestApp, cache_backend: TCacheBackendFixture) -> None:
     call_counter = {"count": 0}
 
-    @cache.lru_cache(expire=2)
+    @cache.func_cache(expire=2)
     async def add(a: int, b: int) -> int:
         call_counter["count"] += 1
         return a + b


### PR DESCRIPTION
- make cache more robust by using lua scripts for enforcing atomicity of certain operations
- rename cache decorator name from lru_cache to func_cache, because it does not behave like an LRU cache
- sets can now have an expiration
- index sets share the expiration of their keys, making clean up easier